### PR TITLE
ci: reduce test logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       maven_args:
         description: The arguments to pass to all Maven commands when running tests
         required: false
-        default: '-Dcheck.skip-dependency=true -Dcheck.skip-dependency-scope=true -Dcheck.skip-dependency-versions=true -Dcheck.skip-duplicate-finder=true -Dcheck.skip-enforcer=true -Dcheck.skip-rat=true -Dcheck.skip-spotbugs=true'
+        default: '-Dmaven.test.redirectTestOutputToFile=true -Dcheck.skip-dependency=true -Dcheck.skip-dependency-scope=true -Dcheck.skip-dependency-versions=true -Dcheck.skip-duplicate-finder=true -Dcheck.skip-enforcer=true -Dcheck.skip-rat=true -Dcheck.skip-spotbugs=true'
         type: string
       verify_maven_args:
         description: The arguments to pass to all Maven commands when verifying build
@@ -104,7 +104,13 @@ on:
       failure-upload-path:
         description: A file, directory or wildcard pattern that describes what to upload on failure
         required: false
+        default: '**/surefire-reports/*'
         type: string
+      failure-upload-retention-days:
+        description: Number of days to keep the files
+        required: false
+        default: 7
+        type: number
 
 jobs:
   # verify build on one node - before matrix will start
@@ -141,6 +147,7 @@ jobs:
         with:
           name: failure-${{ inputs.ff-os }}-${{ inputs.ff-jdk }}-${{ inputs.ff-jdk-distribution }}
           path: ${{ inputs.failure-upload-path }}
+          retention-days: ${{ inputs.failure-upload-retention-days }}
   test:
     needs: fail-fast-build
     name: jdk-${{ matrix.jdk }} ${{ matrix.profile }}
@@ -196,6 +203,7 @@ jobs:
         with:
           name: failure-${{ matrix.os }}-${{ matrix.jdk }}-${{ matrix.distribution }}
           path: ${{ inputs.failure-upload-path }}
+          retention-days: ${{ inputs.failure-upload-retention-days }}
   verify:
     needs: fail-fast-build
     name: verify
@@ -228,3 +236,4 @@ jobs:
         with:
           name: failure-verify-${{ inputs.ff-os }}-${{ inputs.ff-jdk }}-${{ inputs.ff-jdk-distribution }}
           path: ${{ inputs.failure-upload-path }}
+          retention-days: ${{ inputs.failure-upload-retention-days }}


### PR DESCRIPTION
`maven.test.redirectTestOutputToFile=true` will reduce the output. This will hopefully help with the GitHub actions log UI / scrolling.

Before:

```
2022-05-17T13:05:36.8365772Z [INFO] -------------------------------------------------------
2022-05-17T13:05:36.8366346Z [INFO]  T E S T S
2022-05-17T13:05:36.8414497Z [INFO] -------------------------------------------------------
2022-05-17T13:05:37.1611318Z [INFO] Running TestSuite
2022-05-17T13:05:37.3139181Z Configuring TestNG with: TestNG740Configurator
2022-05-17T13:05:38.1087033Z 2022-05-17T13:05:38.105+0000 [main] INFO org.killbill.clock.ClockMock -             ************      ADJUSTING CLOCK FROM 2022-05-17T13:05:38.000Z to 2012-05-01T01:02:03.000Z     ********************
2022-05-17T13:05:38.1195895Z 2022-05-17T13:05:38.116+0000 [main] INFO org.killbill.clock.ClockMock -             ************      ADJUSTING CLOCK FROM 2012-05-01T01:02:03.000Z to 2012-05-02T01:02:03.000Z     ********************
2022-05-17T13:05:38.1196861Z 2022-05-17T13:05:38.117+0000 [main] INFO org.killbill.clock.ClockMock -             ************      ADJUSTING CLOCK FROM 2012-05-02T01:02:03.000Z to 2012-06-02T01:02:03.000Z     ********************
2022-05-17T13:05:38.1197899Z 2022-05-17T13:05:38.118+0000 [main] INFO org.killbill.clock.ClockMock -             ************      ADJUSTING CLOCK FROM 2012-06-02T01:02:03.000Z to 2013-06-02T01:02:03.000Z     ********************
2022-05-17T13:05:38.1199109Z 2022-05-17T13:05:38.118+0000 [main] INFO org.killbill.clock.ClockMock -             ************      ADJUSTING CLOCK FROM 2013-06-02T01:02:03.000Z to 2045-12-12T00:00:00.000Z     ********************
2022-05-17T13:05:38.1200109Z 2022-05-17T13:05:38.118+0000 [main] INFO org.killbill.clock.ClockMock -             ************      ADJUSTING CLOCK FROM 2045-12-12T00:00:00.000Z to 2022-05-17T13:05:38.000Z     ********************
2022-05-17T13:05:38.5093717Z 2022-05-17T13:05:38.416+0000 [main] INFO org.redisson.Version - Redisson 3.17.1
2022-05-17T13:05:38.8182696Z 2022-05-17T13:05:38.733+0000 [redisson-netty-2-13] INFO org.redisson.connection.pool.MasterPubSubConnectionPool - 1 connections initialized for 127.0.0.1/127.0.0.1:56379
2022-05-17T13:05:38.9154046Z 2022-05-17T13:05:38.836+0000 [redisson-netty-2-19] INFO org.redisson.connection.pool.MasterConnectionPool - 24 connections initialized for 127.0.0.1/127.0.0.1:56379
2022-05-17T13:05:39.1162178Z 2022-05-17T13:05:39.094+0000 [main] INFO org.killbill.clock.ClockMock -             ************      ADJUSTING CLOCK FROM 2022-05-17T13:05:39.000Z to 2012-05-01T01:02:03.000Z     ********************
2022-05-17T13:05:39.1165659Z 2022-05-17T13:05:39.100+0000 [main] INFO org.killbill.clock.ClockMock -             ************      ADJUSTING CLOCK FROM 2012-05-01T01:02:03.000Z to 2012-05-02T01:02:03.000Z     ********************
2022-05-17T13:05:39.1166860Z 2022-05-17T13:05:39.106+0000 [main] INFO org.killbill.clock.ClockMock -             ************      ADJUSTING CLOCK FROM 2012-05-02T01:02:03.000Z to 2012-06-02T01:02:03.000Z     ********************
2022-05-17T13:05:39.1167726Z 2022-05-17T13:05:39.110+0000 [main] INFO org.killbill.clock.ClockMock -             ************      ADJUSTING CLOCK FROM 2012-06-02T01:02:03.000Z to 2013-06-02T01:02:03.000Z     ********************
2022-05-17T13:05:39.1169021Z 2022-05-17T13:05:39.113+0000 [main] INFO org.killbill.clock.ClockMock -             ************      ADJUSTING CLOCK FROM 2013-06-02T01:02:03.000Z to 2045-12-12T00:00:00.000Z     ********************
2022-05-17T13:05:39.1641626Z 2022-05-17T13:05:39.118+0000 [main] INFO org.killbill.clock.ClockMock -             ************      ADJUSTING CLOCK FROM 2045-12-12T00:00:00.000Z to 2022-05-17T13:05:39.000Z     ********************
2022-05-17T13:05:39.2162830Z 2022-05-17T13:05:39.165+0000 [main] INFO redis.embedded.AbstractRedisInstance - Stopping redis server...
2022-05-17T13:05:39.2920672Z 2022-05-17T13:05:39.223+0000 [main] INFO redis.embedded.AbstractRedisInstance - Redis exited
2022-05-17T13:05:39.3244157Z [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.137 s - in TestSuite
2022-05-17T13:05:39.3391873Z [INFO] 
2022-05-17T13:05:39.3392534Z [INFO] Results:
2022-05-17T13:05:39.3394364Z [INFO] 
2022-05-17T13:05:39.3395083Z [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
2022-05-17T13:05:39.3395494Z [INFO] 
2022-05-17T13:05:39.3417730Z [INFO] 
```

After:

```
2022-05-17T13:23:14.2054323Z [INFO] -------------------------------------------------------
2022-05-17T13:23:14.2054612Z [INFO]  T E S T S
2022-05-17T13:23:14.2054967Z [INFO] -------------------------------------------------------
2022-05-17T13:23:14.4925564Z [INFO] Running TestSuite
2022-05-17T13:23:16.2386363Z [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.723 s - in TestSuite
2022-05-17T13:23:16.2539360Z [INFO] 
2022-05-17T13:23:16.2539883Z [INFO] Results:
2022-05-17T13:23:16.2540165Z [INFO] 
2022-05-17T13:23:16.2540501Z [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
2022-05-17T13:23:16.2541116Z [INFO] 
```

In case of failures, we still see:

```
2022-05-17T13:23:43.5081834Z [INFO] -------------------------------------------------------
2022-05-17T13:23:43.5082336Z [INFO]  T E S T S
2022-05-17T13:23:43.5084685Z [INFO] -------------------------------------------------------
2022-05-17T13:23:43.7350711Z [INFO] Running org.killbill.commons.embeddeddb.mysql.TestKillBillMariaDbDataSource
2022-05-17T13:23:44.1264038Z [ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.389 s <<< FAILURE! - in org.killbill.commons.embeddeddb.mysql.TestKillBillMariaDbDataSource
2022-05-17T13:23:44.1268944Z [ERROR] org.killbill.commons.embeddeddb.mysql.TestKillBillMariaDbDataSource.testUpdateUrl  Time elapsed: 0.048 s  <<< FAILURE!
2022-05-17T13:23:44.1270203Z java.lang.AssertionError: expected [jdbc:mysql://127.0.0.1:3306/killbill?allowMultiQueries=true&cachePrepStmts=false&createDatabaseIfNotExist=true&permitMysqlScheme=true] but found [Xjdbc:mysql://127.0.0.1:3306/killbill?createDatabaseIfNotExist=true&allowMultiQueries=true&cachePrepStmts=false]
2022-05-17T13:23:44.1271206Z 	at org.testng.Assert.fail(Assert.java:110)
2022-05-17T13:23:44.1272748Z 	at org.testng.Assert.failNotEquals(Assert.java:1413)
2022-05-17T13:23:44.1273249Z 	at org.testng.Assert.assertEqualsImpl(Assert.java:149)
2022-05-17T13:23:44.1273750Z 	at org.testng.Assert.assertEquals(Assert.java:131)
2022-05-17T13:23:44.1274348Z 	at org.testng.Assert.assertEquals(Assert.java:655)
2022-05-17T13:23:44.1275171Z 	at org.testng.Assert.assertEquals(Assert.java:665)
2022-05-17T13:23:44.1275806Z 	at org.killbill.commons.embeddeddb.mysql.TestKillBillMariaDbDataSource.testUpdateUrl(TestKillBillMariaDbDataSource.java:31)
2022-05-17T13:23:44.1276484Z 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
2022-05-17T13:23:44.1277259Z 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
2022-05-17T13:23:44.1277880Z 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
2022-05-17T13:23:44.1278720Z 	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
2022-05-17T13:23:44.1279278Z 	at org.testng.internal.invokers.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:135)
2022-05-17T13:23:44.1279853Z 	at org.testng.internal.invokers.TestInvoker.invokeMethod(TestInvoker.java:673)
2022-05-17T13:23:44.1280371Z 	at org.testng.internal.invokers.TestInvoker.invokeTestMethod(TestInvoker.java:220)
2022-05-17T13:23:44.1280881Z 	at org.testng.internal.invokers.MethodRunner.runInSequence(MethodRunner.java:50)
2022-05-17T13:23:44.1281417Z 	at org.testng.internal.invokers.TestInvoker$MethodInvocationAgent.invoke(TestInvoker.java:945)
2022-05-17T13:23:44.1281943Z 	at org.testng.internal.invokers.TestInvoker.invokeTestMethods(TestInvoker.java:193)
2022-05-17T13:23:44.1282499Z 	at org.testng.internal.invokers.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:146)
2022-05-17T13:23:44.1283044Z 	at org.testng.internal.invokers.TestMethodWorker.run(TestMethodWorker.java:128)
2022-05-17T13:23:44.1283471Z 	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
2022-05-17T13:23:44.1283841Z 	at org.testng.TestRunner.privateRun(TestRunner.java:808)
2022-05-17T13:23:44.1284173Z 	at org.testng.TestRunner.run(TestRunner.java:603)
2022-05-17T13:23:44.1284517Z 	at org.testng.SuiteRunner.runTest(SuiteRunner.java:429)
2022-05-17T13:23:44.1284896Z 	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:423)
2022-05-17T13:23:44.1285273Z 	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:383)
2022-05-17T13:23:44.1285624Z 	at org.testng.SuiteRunner.run(SuiteRunner.java:326)
2022-05-17T13:23:44.1286002Z 	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
2022-05-17T13:23:44.1286400Z 	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:95)
2022-05-17T13:23:44.1286792Z 	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1249)
2022-05-17T13:23:44.1287166Z 	at org.testng.TestNG.runSuitesLocally(TestNG.java:1169)
2022-05-17T13:23:44.1287503Z 	at org.testng.TestNG.runSuites(TestNG.java:1092)
2022-05-17T13:23:44.1287913Z 	at org.testng.TestNG.run(TestNG.java:1060)
2022-05-17T13:23:44.1288312Z 	at org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:151)
2022-05-17T13:23:44.1288946Z 	at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.executeSingleClass(TestNGDirectoryTestSuite.java:111)
2022-05-17T13:23:44.1289633Z 	at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.execute(TestNGDirectoryTestSuite.java:98)
2022-05-17T13:23:44.1290214Z 	at org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:155)
2022-05-17T13:23:44.1290766Z 	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:456)
2022-05-17T13:23:44.1291313Z 	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:169)
2022-05-17T13:23:44.1291785Z 	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:595)
2022-05-17T13:23:44.1292262Z 	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:581)
2022-05-17T13:23:44.1292528Z 
2022-05-17T13:23:44.1510782Z [INFO] 
2022-05-17T13:23:44.1546835Z [INFO] Results:
2022-05-17T13:23:44.1559221Z [INFO] 
2022-05-17T13:23:44.1559566Z [ERROR] Failures: 
2022-05-17T13:23:44.1560536Z [ERROR]   TestKillBillMariaDbDataSource.testUpdateUrl:31 expected [jdbc:mysql://127.0.0.1:3306/killbill?allowMultiQueries=true&cachePrepStmts=false&createDatabaseIfNotExist=true&permitMysqlScheme=true] but found [Xjdbc:mysql://127.0.0.1:3306/killbill?createDatabaseIfNotExist=true&allowMultiQueries=true&cachePrepStmts=false]
2022-05-17T13:23:44.1561759Z [INFO] 
2022-05-17T13:23:44.1562079Z [ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
2022-05-17T13:23:44.1562320Z [INFO] 
```

Also, the surefire reports are now uploaded for ease of debugging.