### PR TITLE
add update rubygems

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -113,6 +113,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
+          rubygems: latest
           bundler-cache: true
       - name: Install kpm
         run: |


### PR DESCRIPTION
Add extra step to update rubygems, in attempt to fix:

```
Your RubyGems version (2.7.3) has a bug that prevents `required_ruby_version` from working for Bundler. 
Any scripts that use `gem install bundler` will break as soon as Bundler drops support for your Ruby version. 
Please upgrade RubyGems to avoid future breakage and silence this warning by running `gem update --system 3.2.3`

```