### PR TITLE
Add support for GitHub packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,8 +144,8 @@ jobs:
         with:
           mirrors: '[{"id": "oss-releases", "name": "Sonatype releases", "mirrorOf": "central", "url": "https://oss.sonatype.org/content/repositories/releases"}]'
           sonatypeSnapshots: true
-      - name: Configure Maven
-        uses: s4u/maven-settings-action@v2.2.0
+          githubServer: false
+          servers: '[{"id": "github","configuration": {"httpHeaders": {"property": {"name": "Authorization","value": "Bearer ${{ secrets.GITHUB_TOKEN }}"}}}}]'
       - name: Set up Maven
         run: mvn --errors --batch-mode --show-version wrapper:wrapper "-Dmaven=${{ inputs.maven_version }}"
       - name: Run tests
@@ -204,6 +204,8 @@ jobs:
         with:
           mirrors: '[{"id": "oss-releases", "name": "Sonatype releases", "mirrorOf": "central", "url": "https://oss.sonatype.org/content/repositories/releases"}]'
           sonatypeSnapshots: true
+          githubServer: false
+          servers: '[{"id": "github","configuration": {"httpHeaders": {"property": {"name": "Authorization","value": "Bearer ${{ secrets.GITHUB_TOKEN }}"}}}}]'
       - name: Set up Maven
         if: steps.should-run.conclusion == 'success'
         run: mvn --errors --batch-mode --show-version wrapper:wrapper "-Dmaven=${{ inputs.maven_version }}"
@@ -243,6 +245,8 @@ jobs:
         with:
           mirrors: '[{"id": "oss-releases", "name": "Sonatype releases", "mirrorOf": "central", "url": "https://oss.sonatype.org/content/repositories/releases"}]'
           sonatypeSnapshots: true
+          githubServer: false
+          servers: '[{"id": "github","configuration": {"httpHeaders": {"property": {"name": "Authorization","value": "Bearer ${{ secrets.GITHUB_TOKEN }}"}}}}]'
       - name: Set up Maven
         run: mvn --errors --batch-mode --show-version wrapper:wrapper "-Dmaven=${{ inputs.maven_version }}"
       - name: Verify

--- a/.github/workflows/cloudsmith_release.yml
+++ b/.github/workflows/cloudsmith_release.yml
@@ -93,11 +93,16 @@ jobs:
         with:
           mirrors: '[{"id": "oss-releases", "name": "Sonatype releases", "mirrorOf": "central", "url": "https://oss.sonatype.org/content/repositories/releases"}]'
           sonatypeSnapshots: true
+          githubServer: false
           servers: |
             [{
                 "id": "${CLOUDSMITH_REPO}",
                 "username": "${CLOUDSMITH_USER}",
                 "password": "${CLOUDSMITH_API_KEY}"
+            },
+            {
+                "id": "github",
+                "configuration": {"httpHeaders": {"property": {"name": "Authorization","value": "Bearer ${{ secrets.GITHUB_TOKEN }}"}}}
             }]
       - name: Set up Maven
         run: mvn --errors --batch-mode --show-version wrapper:wrapper "-Dmaven=${{ inputs.maven_version }}"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -69,6 +69,8 @@ jobs:
         with:
           mirrors: '[{"id": "oss-releases", "name": "Sonatype releases", "mirrorOf": "central", "url": "https://oss.sonatype.org/content/repositories/releases"}]'
           sonatypeSnapshots: true
+          githubServer: false
+          servers: '[{"id": "github","configuration": {"httpHeaders": {"property": {"name": "Authorization","value": "Bearer ${{ secrets.GITHUB_TOKEN }}"}}}}]'
       - name: Set up Maven
         run: mvn --errors --batch-mode --show-version wrapper:wrapper "-Dmaven=${{ inputs.maven_version }}"
       - name: Initialize CodeQL

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -109,6 +109,8 @@ jobs:
         with:
           mirrors: '[{"id": "oss-releases", "name": "Sonatype releases", "mirrorOf": "central", "url": "https://oss.sonatype.org/content/repositories/releases"}]'
           sonatypeSnapshots: true
+          githubServer: false
+          servers: '[{"id": "github","configuration": {"httpHeaders": {"property": {"name": "Authorization","value": "Bearer ${{ secrets.GITHUB_TOKEN }}"}}}}]'
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -78,6 +78,10 @@ jobs:
                 "id": "sonatype-nexus-snapshots",
                 "username": "${OSSRH_USER}",
                 "password": "${OSSRH_PASS}"
+            },
+            {
+                "id": "github",
+                "configuration": {"httpHeaders": {"property": {"name": "Authorization","value": "Bearer ${{ secrets.GITHUB_TOKEN }}"}}}
             }]
       - name: Set up Maven
         run: mvn --errors --batch-mode --show-version wrapper:wrapper "-Dmaven=${{ inputs.maven_version }}"


### PR DESCRIPTION
Here's the diff between the previous settings.xml and the new one:

```
@@ -54,13 +54,13 @@
     <servers>
 <server>
     <id>github</id>
-    <username>${env.GITHUB_ACTOR}</username>
-    <password>${env.GITHUB_TOKEN}</password>
+    <configuration><httpHeaders><property><name>Authorization</name><value>***
 </server></servers>
     <mirrors>
 <mirror>
```

For reference, the full settings.xml is now:

```
<settings>
    <interactiveMode>false</interactiveMode>
    <profiles>
<profile>
    <id>_sonatype-snapshots_</id>
    <activation>
        <activeByDefault>true</activeByDefault>
    </activation>
    <repositories>
        <repository>
            <id>sonatype-snapshots</id>
            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
            <releases>
                <enabled>false</enabled>
            </releases>
            <snapshots>
                <enabled>true</enabled>
            </snapshots>
        </repository>
        <repository>
            <id>ossrh</id>
            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
            <releases>
                <enabled>false</enabled>
            </releases>
            <snapshots>
                <enabled>true</enabled>
            </snapshots>
        </repository>
    </repositories>
    <pluginRepositories>
        <pluginRepository>
            <id>sonatype-snapshots</id>
            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
            <releases>
                <enabled>false</enabled>
            </releases>
            <snapshots>
                <enabled>true</enabled>
            </snapshots>
        </pluginRepository>
        <pluginRepository>
            <id>ossrh</id>
            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
            <releases>
                <enabled>false</enabled>
            </releases>
            <snapshots>
                <enabled>true</enabled>
            </snapshots>
        </pluginRepository>
    </pluginRepositories>
</profile></profiles>
    <servers>
<server>
    <id>github</id>
    
    
    
    
    
    
    <configuration><httpHeaders><property><name>Authorization</name><value>***
</server></servers>
    <mirrors>
<mirror>
    <id>oss-releases</id>
    <name>Sonatype releases</name>
    <mirrorOf>central</mirrorOf>
    <url>https://oss.sonatype.org/content/repositories/releases</url>
</mirror></mirrors>
    <proxies/>
</settings>
```

Note: this can be debugged by adding in the workflow

```
      - run: cat ~/.m2/settings.xml
        shell: bash
```