### PR TITLE
Changed failure upload path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,5 +256,5 @@ jobs:
         if: failure() && inputs.failure-upload-path != ''
         with:
           name: failure-verify-${{ inputs.ff-os }}-${{ inputs.ff-jdk }}-${{ inputs.ff-jdk-distribution }}
-          path: ${{ inputs.failure-upload-path }}
+          path: 'target/*'
           retention-days: ${{ inputs.failure-upload-retention-days }}


### PR DESCRIPTION
Set the failure-upload-path for the `verify` job to `'target/*'`