### PR TITLE
Fix missing libaio on latest ubuntu image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ on:
       os-matrix:
         description: 'os matrix as json array'
         required: false
-        default: '[ "ubuntu-latest" ]'
+        default: '[ "ubuntu-22.04" ]'
         type: string
       jdk-matrix:
         description: 'jdk matrix as json array'
@@ -57,7 +57,7 @@ on:
       ff-os:
         description: The os used during fail-fast-build job
         required: false
-        default: 'ubuntu-latest'
+        default: 'ubuntu-22.04'
         type: string
       ff-jdk:
         description: The jdk version used during fail-fast-build job

--- a/.github/workflows/cloudsmith_release.yml
+++ b/.github/workflows/cloudsmith_release.yml
@@ -33,7 +33,7 @@ on:
       os:
         description: The OS used
         required: false
-        default: 'ubuntu-latest'
+        default: 'ubuntu-22.04'
         type: string
       jdk:
         description: The JDK used

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,7 +19,7 @@ on:
       os:
         description: The OS used
         required: false
-        default: 'ubuntu-latest'
+        default: 'ubuntu-22.04'
         type: string
       jdk:
         description: The JDK used

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -86,7 +86,7 @@ jobs:
   integration_test:
     name: jdk-${{ matrix.java-version }} ${{ matrix.database-adapter }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: ${{ inputs.fail-fast }}
       matrix:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -24,7 +24,7 @@ on:
       os:
         description: The OS used
         required: false
-        default: 'ubuntu-latest'
+        default: 'ubuntu-22.04'
         type: string
       jdk:
         description: The JDK used

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -10,7 +10,7 @@ on:
       os:
         description: The OS used
         required: false
-        default: 'ubuntu-latest'
+        default: 'ubuntu-22.04'
         type: string
       timeout-minutes:
         description: 'timeout-minutes used by the builds (defaults to 360)'


### PR DESCRIPTION
It looks like GH action changed the [default](https://github.com/actions/runner-images?tab=readme-ov-file#available-images) `ubuntu-latest` to be `ubuntu-24.04 `. As a result I started to see some tests fail:

<img width="1068" alt="Screenshot 2025-01-14 at 9 32 31 AM" src="https://github.com/user-attachments/assets/5b74cc15-e5f7-4179-a130-041c1ae392a5" />

I tried to add the missing `libaio1` package as shown [here](https://github.com/killbill/gh-actions-shared/compare/main...libaio?expand=1), but that did not work. It looks like the name of the package [may have changed](https://askubuntu.com/a/1526423).

So, I figured we could pin the version to `ubuntu-22.04` to avoid these breaking changes.

I updated all jobs in [be8d873](https://github.com/killbill/gh-actions-shared/pull/67/commits/be8d8739b75f24cf44bb3cba0e82c315c10e3633), and filed the issue https://github.com/killbill/gh-actions-shared/issues/68 to review.

